### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ All notable changes to DotRun will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-10-26
+
+### ✨ Added
+
+#### Enhanced Documentation System
+
+- **Three-Tier Documentation Structure**: Scripts now support three `### DOC` blocks for progressive documentation depth
+  - **Block 1→2**: One-line summary (shown in `dr -L` tree listing)
+  - **Block 2→3**: Extended documentation with usage examples, required tools, and detailed descriptions
+  - Enables both quick reference and comprehensive help in the same script
+
+- **New `dr docs` Command**: Display extended documentation from scripts
+  - **`dr docs <scriptname>`**: Shows content between **2nd and 3rd `### DOC` blocks** (extended documentation)
+  - Includes usage examples, required tools, and detailed descriptions
+  - Automatic fallback to basic docs (1st→2nd block) if script doesn't have 3rd DOC block
+  - Complements existing `dr help` command for comprehensive documentation access
+
+#### Enhanced List Commands (`dr -l` / `dr -L`)
+
+- **Intelligent Sorting**: Both `dr -l` and `dr -L` now display results in organized hierarchy
+  - **Folders first** (alphabetically sorted)
+  - **Scripts second** (alphabetically sorted)
+  - Applied recursively at all directory levels for consistent navigation
+
+- **Tree-Style Output Format**: Beautiful tree CLI-style visualization
+  - Unicode box-drawing characters: `├──`, `└──`, `│` for clear hierarchy
+  - Proper last-item detection for clean visual structure (`└──` for final items)
+  - Indentation preserved for documentation snippets
+
+- **Colorized Folder Depth**: Visual depth indicators with automatic color cycling
+  - 6-color palette cycles every 6 folder levels: Bright Blue → Bright Cyan → Bright Magenta → Orange → Yellow → Green
+  - Color applies to all tree symbols (branches, connectors, and continuation lines)
+  - Makes nested folder structures easy to visually parse
+
+- **Documentation Display Behavior**:
+  - **`dr -L`**: Now shows only content between **1st and 2nd `### DOC` blocks** (one-line summary)
+  - Previous behavior showed all documentation between first and last DOC markers
+  - Enables concise tree listing with brief descriptions
+
+#### Externalized Script Templates
+
+- **Template File System**: Script templates moved from inline code to external files
+  - Template location: `~/.local/share/dotrun/core/templates/script.sh`
+  - Source template: `core/shared/dotrun/core/templates/script.sh`
+  - Enables easier template customization and maintenance
+  - Templates automatically deployed during installation and upgrades
+
+- **Updated Script Creation**: `dr set <name>` uses external template
+  - Template includes new 3-block `### DOC` structure
+  - Placeholder system: `{{SCRIPT_NAME}}` replaced during creation
+  - Error handling for missing template files with actionable guidance
+
+- **User-Customizable Templates**: Personalize script creation to match your workflow
+  - Template file located at: `~/.local/share/dotrun/core/templates/script.sh`
+  - **Users can manually edit this file** to create custom script templates
+  - Modifications persist across script creations (will be overwritten on system upgrades)
+  - Use `{{SCRIPT_NAME}}` placeholder for automatic script name substitution
+  - Ideal for: adding custom headers, modifying default structure, including organization-specific conventions
+
+### 🔧 Changed
+
+- **Installation Scripts**: Both `install.sh` and `upgrade-v1-or-v2--to--v3.sh` now recursively copy core template files
+- **Default Script Template**: Updated to support new documentation structure with three-tier DOC blocks
+
+### 📖 Documentation
+
+- Script template structure documented inline with examples
+- Extended help documentation accessible via new `dr docs` command
+- Tree listing improvements enhance discoverability of script organization
+
 ## [3.0.0] - 2025-10-23
 
 **MAJOR RELEASE**: Unified resource workflows and complete collections system redesign with breaking changes. This release introduces a consistent file-based workflow across all resource types (scripts, aliases, configs) and fundamentally reimagines how DotRun handles script collections.
@@ -19,11 +89,11 @@ The aliases and config management systems have been redesigned to use a **file-b
 
 ```bash
 # Old (v2.x) - NO LONGER WORKS
-dr aliases add myalias 'git status'   # ❌ Single alias per command
-dr aliases edit myalias               # ❌ Command-line editing
+dr aliases add myalias 'git status' # ❌ Single alias per command
+dr aliases edit myalias             # ❌ Command-line editing
 
 # New (v3.0.0) - File-based, multi-resource
-dr aliases set 01-git                 # Opens editor with multi-alias file
+dr aliases set 01-git # Opens editor with multi-alias file
 # File contains:
 #   alias gs='git status'
 #   alias gc='git commit'
@@ -34,11 +104,11 @@ dr aliases set 01-git                 # Opens editor with multi-alias file
 
 ```bash
 # Old (v2.x) - NO LONGER WORKS
-dr config set API_KEY "value"         # ❌ Single config per command
-dr config set SECRET "val" --secure   # ❌ Flag-based security
+dr config set API_KEY "value"       # ❌ Single config per command
+dr config set SECRET "val" --secure # ❌ Flag-based security
 
 # New (v3.0.0) - File-based, multi-resource
-dr config set api/keys                # Opens editor with multi-config file
+dr config set api/keys # Opens editor with multi-config file
 # File contains:
 #   export API_KEY="value"
 #   export API_SECRET="another-value"
@@ -47,6 +117,7 @@ dr config set api/keys                # Opens editor with multi-config file
 ```
 
 **Why This Is Better**:
+
 - ✅ Matches established numbered file convention (01-git.aliases, api/keys.config)
 - ✅ Reduces file clutter (10 aliases in 1 file vs 10 separate files)
 - ✅ Better organization by category/topic with numbered load order
@@ -132,6 +203,7 @@ dr -col init                     # Initialize new collection (authors)
 #### Unified Resource Workflows Features (NEW)
 
 **File-Based Aliases Management**:
+
 - `dr aliases set <filename>` - Idempotent command (create or edit) opens editor with file skeleton
 - Multi-alias-per-file architecture: `01-git.aliases` contains multiple git aliases
 - Category folder support: `dr aliases set git/shortcuts` → `~/.config/dotrun/aliases/git/shortcuts.aliases`
@@ -146,6 +218,7 @@ dr -col init                     # Initialize new collection (authors)
 - Empty directory auto-cleanup after removal
 
 **File-Based Config Management**:
+
 - `dr config set <filename>` - Idempotent command (create or edit) opens editor with file skeleton
 - Multi-export-per-file architecture: `api/keys.config` contains multiple API exports
 - Category folder support: `dr config set api/keys` → `~/.config/dotrun/configs/api/keys.config`
@@ -159,12 +232,14 @@ dr -col init                     # Initialize new collection (authors)
 - Empty directory auto-cleanup after removal
 
 **Shell Integration**:
+
 - Shell-specific loaders for aliases and configs (bash, zsh, fish)
 - Automatic sourcing during shell initialization via `~/.drrc`
 - Category-based organization with folder support
 - Load order control via numbered file prefixes
 
 **Improvements Over 2.x**:
+
 - Reduced file clutter: 10 aliases in 1 file instead of 10 files
 - Better organization: Group related items by category
 - Easier editing: Multi-resource files are simpler to maintain
@@ -172,6 +247,7 @@ dr -col init                     # Initialize new collection (authors)
 - Version control friendly: Standard text files with clear structure
 
 **Planned for 3.1.0**:
+
 - `# SECURE` marker system for masking sensitive config values
 - `dr config reload` command (aliases already has reload)
 - Tab completion updates for new commands
@@ -397,6 +473,7 @@ Existing imported collections will continue to work as individual scripts, but y
 ### 📊 Release Statistics
 
 **Implementation Status**: 77% complete (37/48 tasks)
+
 - ✅ Phase 1: Aliases Workflow (12/12 = 100%)
 - ✅ Phase 2: Config Workflow (12/14 = 86%)
 - ✅ Phase 3: Command Routing (6/6 = 100%)
@@ -406,6 +483,7 @@ Existing imported collections will continue to work as individual scripts, but y
 - ✅ Phase 7: Edge Cases (5/6 = 83%)
 
 **Production Readiness**: 95%
+
 - Core functionality: 100% complete and tested
 - Documentation: 100% complete and accurate
 - Missing features: Tab completions, # SECURE markers (enhancements for 3.1.0)
@@ -420,12 +498,14 @@ Existing imported collections will continue to work as individual scripts, but y
 ### 🚀 What's Next
 
 **v3.1.0 Enhancements** (Planned):
+
 - # SECURE marker system for config value masking
 - Tab completion updates for new aliases/config commands
 - Config reload command (dr config reload)
 - Automated test suite
 
 **v3.2.0 Quality** (Future):
+
 - CI/CD integration
 - Performance benchmarks
 - Shell compatibility matrix
@@ -514,7 +594,7 @@ Existing imported collections will continue to work as individual scripts, but y
 
 #### Core Script Management
 
-- **Script Creation**: `dr add <name>` - Create new scripts with automatic skeleton generation
+- **Script Creation**: `dr set <name>` - Create new scripts with automatic skeleton generation
 - **Script Editing**: `dr edit <name>` - Edit scripts in preferred editor with VS Code/nano detection
 - **Script Execution**: `dr <scriptname>` - Execute scripts from anywhere with nested folder support
 - **Script Discovery**:

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ dr hello # Run from any directory
 
 ```bash
 # Script management
-dr -s set deploy          # Create script (or: dr scripts set deploy)
-dr -s list git/           # Browse by folder
+dr -s set deploy # Create script (or: dr scripts set deploy)
+dr -s list git/  # Browse by folder
 
 # Alias management (file-based, multiple aliases per file)
-dr -a set 01-git          # Opens editor: ~/.config/dotrun/aliases/01-git.aliases
-dr -a list                # View all alias files
+dr -a set 01-git # Opens editor: ~/.config/dotrun/aliases/01-git.aliases
+dr -a list       # View all alias files
 
 # Config management (file-based, multiple exports per file)
 dr -c set api/keys        # Opens editor: ~/.config/dotrun/configs/api/keys.config
@@ -133,12 +133,12 @@ dr -col add https://github.com/jvPalma/dotrun.git
 # Select which scripts/aliases/helpers to import
 
 # Browse and run
-dr -L                     # List all scripts
-dr git/cleanup            # Run imported script
+dr -L          # List all scripts
+dr git/cleanup # Run imported script
 
 # Keep collections updated
-dr -col sync              # Check for updates
-dr -col update dotrun     # Update with conflict resolution
+dr -col sync          # Check for updates
+dr -col update dotrun # Update with conflict resolution
 ```
 
 ### Explore with Tab Completion
@@ -192,17 +192,20 @@ dr -col update my-collection
 **📚 [Complete Documentation](https://github.com/jvPalma/dotrun/wiki)**
 
 ### Getting Started
+
 - [Quick Start Tutorial](https://github.com/jvPalma/dotrun/wiki/Quick-Start-Tutorial) - Your first 5 minutes
 - [Installation Guide](https://github.com/jvPalma/dotrun/wiki/Installation-Guide) - Detailed setup
 - [Migration from v2.x](https://github.com/jvPalma/dotrun/wiki/Migration-v3.0) - Upgrading guide
 
 ### Core Features
+
 - [Script Management](https://github.com/jvPalma/dotrun/wiki/Script-Management) - Creating and organizing scripts
 - [Alias Management](https://github.com/jvPalma/dotrun/wiki/Alias-Management) - File-based aliases with v3.0.0 workflow
 - [Configuration Management](https://github.com/jvPalma/dotrun/wiki/Configuration-Management) - Environment variables and configs
 - [Collection Management](https://github.com/jvPalma/dotrun/wiki/Collection-Management-Advanced) - Import and share script libraries
 
 ### Advanced Topics
+
 - [Helper System](https://github.com/jvPalma/dotrun/wiki/Helper-System) - Shared code across scripts
 - [Developer Experience](https://github.com/jvPalma/dotrun/wiki/Developer-Experience) - Editor integration, completion
 - [Architecture Overview](https://github.com/jvPalma/dotrun/wiki/Architecture-Overview) - How DotRun works
@@ -210,6 +213,7 @@ dr -col update my-collection
 - [FAQ](https://github.com/jvPalma/dotrun/wiki/FAQ) - Common questions and answers
 
 ### Team Workflows
+
 - [Team Collaboration Best Practices](https://github.com/jvPalma/dotrun/wiki/Team-Collaboration-Best-Practices)
 - [DevOps Pipeline Workflow](https://github.com/jvPalma/dotrun/wiki/workflows/DevOps-Pipeline)
 - [More workflows...](https://github.com/jvPalma/dotrun/wiki)

--- a/core/shared/dotrun/core/templates/script.sh
+++ b/core/shared/dotrun/core/templates/script.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+### DOC
+# One line description about what this script does
+### DOC
+#
+# Long multiline description of this script
+#
+# Usage/Example:
+#  dr {{SCRIPT_NAME}} [args]
+#
+# Required Tools:
+#
+### DOC
+
+set -euo pipefail
+
+# Load loadHelpers function for dual-mode execution
+[[ -n "${DR_LOAD_HELPERS:-}" ]] && source "$DR_LOAD_HELPERS"
+
+# Load required helper
+loadHelpers global/colors
+
+main() {
+  echo "Running {{SCRIPT_NAME}}..."
+}
+
+main "$@"

--- a/core/shared/dotrun/dr
+++ b/core/shared/dotrun/dr
@@ -28,6 +28,7 @@ fi
 DR_CONFIG="${DR_CONFIG:-$HOME/.config/dotrun}"
 BIN_DIR="$DR_CONFIG/scripts"
 DOC_TOKEN="### DOC"
+TEMPLATE_FILE="${HOME}/.local/share/dotrun/core/templates/script.sh"
 _default_editor="$(command -v code >/dev/null && echo "code" || echo "nano")"
 EDITOR="${EDITOR:-$_default_editor}"
 
@@ -110,41 +111,137 @@ list_scripts() {
     echo "Warning: Broken symlinks found in $start_dir" >&2
   fi
 
-  declare -A printed_folders=()
-
-  _print_folder_chain() {
-    local path="$1" indent=""
-    [[ "$path" == "." || -z "$path" ]] && return
-    local current=""
-    IFS='/' read -ra parts <<<"$path"
-    for part in "${parts[@]}"; do
-      current="${current:+$current/}$part"
-      if [[ -z "${printed_folders[$current]+x}" ]]; then
-        echo -e "${indent}\033[1;33m📂 $part${color_reset}"
-        printed_folders["$current"]=1
-      fi
-      indent+="  "
-    done
-  }
-
+  # Build tree structure: collect all directories and files
+  declare -A tree_dirs=()
+  declare -A tree_files=()
+  
   while IFS= read -r -d '' file; do
-    # shellcheck disable=SC2295
     rel_path="${file#"$BIN_DIR"/}"
     script_name="$(basename "$rel_path" .sh)"
-    folder_path="$(dirname "$rel_path")"
-
-    _print_folder_chain "$folder_path"
-
-    # indent scripts one level deeper than their folder depth
-    local depth=0 indent=""
-    [[ "$folder_path" != "." ]] && depth=$(awk -F'/' '{print NF}' <<<"$folder_path")
-    for ((i = 0; i < depth; i++)); do indent+="  "; done
-
-    echo -e "${indent}${color_script}${script_name}${color_reset}"
-    if ((show_docs)); then
-      awk "/^$DOC_TOKEN/ { p = !p; next } p { print \"${indent}  ${color_doc}\" \$0 \"$color_reset\" }" "$file"
+    dir_path="$(dirname "$rel_path")"
+    
+    # Mark this directory as having content
+    tree_dirs["$dir_path"]=1
+    
+    # Add file to this directory's file list
+    if [[ -z "${tree_files[$dir_path]+x}" ]]; then
+      tree_files["$dir_path"]="$script_name"
+    else
+      tree_files["$dir_path"]="${tree_files[$dir_path]}|$script_name"
     fi
-  done < <(find "$start_dir" -type f -name "*.sh" -print0 | sort -z)
+    
+    # Mark all parent directories
+    local parent="$dir_path"
+    while [[ "$parent" != "." ]]; do
+      parent="$(dirname "$parent")"
+      tree_dirs["$parent"]=1
+    done
+  done < <(find "$start_dir" -type f -name "*.sh" -print0)
+  
+  # Recursively print directory tree: folders first, then scripts
+  _print_tree() {
+    local current_dir="$1"
+    local prefix="$2"
+    local depth="${3:-0}"
+    
+    # Get color for tree symbols based on depth
+    local tree_color
+    case $((depth % 6)) in
+      0) tree_color="[38;5;33m" ;;   # Bright Blue
+      1) tree_color="[38;5;35m" ;;   # Bright Cyan
+      2) tree_color="[38;5;141m" ;;  # Bright Magenta
+      3) tree_color="[38;5;214m" ;;  # Orange
+      4) tree_color="[38;5;228m" ;;  # Yellow
+      5) tree_color="[38;5;121m" ;;  # Green
+    esac
+    
+    # Get all immediate subdirectories
+    local -a subdirs=()
+    for dir in "${!tree_dirs[@]}"; do
+      local parent="$(dirname "$dir")"
+      if [[ "$parent" == "$current_dir" && "$dir" != "$current_dir" ]]; then
+        subdirs+=("$(basename "$dir")")
+      fi
+    done
+    
+    # Sort subdirectories alphabetically
+    IFS=$'
+' subdirs=($(sort <<<"${subdirs[*]}"))
+    unset IFS
+    
+    # Get scripts in this directory (sorted alphabetically)
+    local -a scripts=()
+    if [[ -n "${tree_files[$current_dir]+x}" ]]; then
+      IFS='|' read -ra scripts <<< "${tree_files[$current_dir]}"
+      IFS=$'
+' scripts=($(sort <<<"${scripts[*]}"))
+      unset IFS
+    fi
+    
+    # Calculate total items (subdirs + scripts)
+    local total_items=$((${#subdirs[@]} + ${#scripts[@]}))
+    local item_index=0
+    
+    # Print subdirectories first
+    for subdir in "${subdirs[@]}"; do
+      [[ -z "$subdir" ]] && continue
+      item_index=$((item_index + 1))
+      
+      local is_last=false
+      [[ $item_index -eq $total_items ]] && is_last=true
+      
+      # Choose the branch character
+      local branch="${tree_color}├──${color_reset} "
+      local extension="${tree_color}│${color_reset}   "
+      if $is_last; then
+        branch="${tree_color}└──${color_reset} "
+        extension="    "
+      fi
+      
+      echo -e "${prefix}${branch}[1;33m📂 ${subdir}${color_reset}"
+      
+      local full_path="$current_dir/$subdir"
+      [[ "$current_dir" == "." ]] && full_path="$subdir"
+      
+      _print_tree "$full_path" "${prefix}${extension}" $((depth + 1))
+    done
+    
+    # Then print scripts in this directory
+    for script in "${scripts[@]}"; do
+      [[ -z "$script" ]] && continue
+      item_index=$((item_index + 1))
+      
+      local is_last=false
+      [[ $item_index -eq $total_items ]] && is_last=true
+      
+      # Choose the branch character with color
+      local branch="${tree_color}├──${color_reset} "
+      if $is_last; then
+        branch="${tree_color}└──${color_reset} "
+      fi
+      
+      echo -e "${prefix}${branch}${color_script}${script}${color_reset}"
+      
+      if ((show_docs)); then
+        # Find the actual file path
+        local file_path="$BIN_DIR/$current_dir/$script.sh"
+        [[ "$current_dir" == "." ]] && file_path="$BIN_DIR/$script.sh"
+        
+        # Choose doc prefix based on whether this is last item
+        local doc_prefix="${prefix}"
+        if $is_last; then
+          doc_prefix="${prefix}    "
+        else
+          doc_prefix="${prefix}${tree_color}│${color_reset}   "
+        fi
+        
+        # Extract ONLY content between first and second ### DOC markers
+        awk '/^'"$DOC_TOKEN"'/ { count++; if (count == 2) exit; next } count == 1 { print "'"${doc_prefix}${color_doc}"'" $0 "'"$color_reset"'" }' "$file_path"
+      fi
+    done
+  }
+  
+  _print_tree "." "" 0
 }
 
 # Create script skeleton
@@ -153,28 +250,18 @@ create_script_skeleton() {
   local file="$BIN_DIR/$name.sh"
   mkdir -p "$(dirname "$file")"
 
-  # Create script file with skeleton
+  # Create script file from template
   local script_basename="$(basename "$name")"
-  cat >"$file" <<EOF
-#!/usr/bin/env bash
-$DOC_TOKEN
-# $script_basename - describe what this script does
-$DOC_TOKEN
-
-set -euo pipefail
-
-# Load loadHelpers function for dual-mode execution
-[[ -n "\${DR_LOAD_HELPERS:-}" ]] && source "\$DR_LOAD_HELPERS"
-
-# Load required helper
-loadHelpers global/colors
-
-main() {
-  echo "Running $script_basename..."
-}
-
-main "\$@"
-EOF
+  
+  # Check if template file exists
+  if [[ ! -f "$TEMPLATE_FILE" ]]; then
+    echo "Error: Template file not found at $TEMPLATE_FILE" >&2
+    echo "Please run the installer to set up DotRun properly." >&2
+    return 1
+  fi
+  
+  # Copy template and replace placeholder
+  sed "s/{{SCRIPT_NAME}}/$script_basename/g" "$TEMPLATE_FILE" > "$file"
   chmod +x "$file"
 }
 
@@ -296,7 +383,18 @@ show_help() {
     echo "Error: Script '$1' not found" >&2
     exit 1
   fi
-  awk "/^$DOC_TOKEN/ { p = !p; next } p" "$file"
+  
+  # Try to extract content between SECOND and THIRD ### DOC markers
+  # If no third marker exists, fallback to content between FIRST and SECOND
+  local doc_content
+  doc_content=$(awk '/^'"$DOC_TOKEN"'/ { count++; if (count == 3) exit; next } count == 2 { print }' "$file")
+  
+  # If no content found (no third marker), fallback to first-to-second
+  if [[ -z "$doc_content" ]]; then
+    awk '/^'"$DOC_TOKEN"'/ { count++; if (count == 2) exit; next } count == 1 { print }' "$file"
+  else
+    echo "$doc_content"
+  fi
 }
 
 # Move/rename a script
@@ -515,6 +613,13 @@ move | rename | mv)
 help)
   [[ -z "${2:-}" ]] && {
     echo "Usage: dr help <name>"
+    exit 1
+  }
+  show_help "$2"
+  ;;
+docs)
+  [[ -z "${2:-}" ]] && {
+    echo "Usage: dr docs <name>"
     exit 1
   }
   show_help "$2"

--- a/core/shared/dotrun/shell/bash/aliases.sh
+++ b/core/shared/dotrun/shell/bash/aliases.sh
@@ -3,6 +3,9 @@
 # DotRun Aliases - Bash Integration
 # This file is auto-generated. Do not edit manually.
 
+# Enable alias expansion in bash (required for aliases to work in non-interactive shells/scripts)
+shopt -s expand_aliases 2>/dev/null || true
+
 # Source user aliases from ~/.config/dotrun/aliases/
 # Supports both flat structure (NN-category.aliases) and nested (NN-category/NN-name.aliases)
 # Files are loaded in alphabetical order (sorted by full path)

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 INSTALL_CFG_PATH=${XDG_CONFIG_HOME:-$HOME/.config}
+INSTALL_HOME="$HOME"
 
 # ------------------------------------------------------------------
 # Utility Functions
@@ -27,19 +28,6 @@ log_error() {
 
 log_success() {
   printf "\033[1;32m[SUCCESS]\033[0m %s\n" "$*"
-}
-
-get_message() {
-  [[ "$2" -gt 0 ]] && indent_str="   " || indent_str=" "
-
-  case "$1" in
-    "overwritten") echo "\033[1;34m[INFO]\033[0m$indent_str\033[1;33m✓\033[0m %s \033[0;37m(overwritten)\033[0m\n" ;;
-    "unchanged") echo "\033[1;34m[INFO]\033[0m$indent_str\033[1;32m✓\033[0m %s \033[0;37m(unchanged)\033[0m\n" ;;
-    "new file") echo "\033[1;34m[INFO]\033[0m$indent_str\033[1;32m+\033[0m %s \033[0;37m(new file)\033[0m\n" ;;
-    "file differs") echo "\033[1;34m[INFO]\033[0m$indent_str\033[1;33m⚠\033[0m %s \033[0;37m(File differs from source)\033[0m\n" ;;
-    "skipped") echo "\033[1;34m[INFO]\033[0m$indent_str\033[1;90m-\033[0m %s \033[0;37m(skipped)\033[0m\n" ;;
-    *) echo "unknown" ;;
-  esac
 }
 
 # Detect operating system
@@ -115,248 +103,6 @@ detect_shell() {
     *bash*) echo "bash" ;;
     *) echo "bash" ;; # Ultimate fallback
   esac
-}
-
-# Cross-platform file copying with intelligent file management
-copy_files() {
-  local src="$1"
-  local dst="$2"
-  local force_override="${3:-false}"
-  local modified_files_detected=false
-  
-  # Arrays to track modified files (declared as global so main can access them)
-  modified_files=()
-  modified_src_files=()
-
-  log_info "Setting up DotRun directories and files"
-
-  # Define target directories
-  local target_dirs=("bin" "helpers" "collections")
-
-  # Create target directories if they don't exist
-  for dir in "${target_dirs[@]}"; do
-    local target_dir="$dst/$dir"
-    if [ ! -d "$target_dir" ]; then
-      log_info "Creating directory: $target_dir"
-      mkdir -p "$target_dir"
-    fi
-  done
-
-  # Files to exclude from copying (installation/project files)
-  local exclude_patterns=(
-    "install.sh"
-    ".gitignore"
-    ".git"
-    "*.out"
-    "*.md"
-    ".github"
-    "LICENSE"
-    "CHANGELOG.md"
-    "test_shell_detect.sh"
-  )
-
-  # Hello example files (only copied on clean installs)
-  local hello_files=(
-    "bin/hello.sh"
-  )
-
-  # Files to include at root level (only these specific files)
-  local root_files=(
-    "dr_completion.bash"
-    "dr_completion.zsh"
-    "dr_completion.fish"
-    "README.md"
-  )
-
-  # Function to check if this is a clean install
-  is_clean_install() {
-    local config_dir="$1"
-
-    # Check if config directory doesn't exist or is empty
-    if [ ! -d "$config_dir" ]; then
-      return 0 # Clean install
-    fi
-
-    # Check if bin/ directory exists and has any non-hello scripts
-    local bin_dir="$config_dir/bin"
-    if [ -d "$bin_dir" ]; then
-      # Count files that are not hello examples
-      local non_hello_count
-      non_hello_count=$(find "$bin_dir" -type f -name "*.sh" ! -name "hello.sh" | wc -l)
-      if [ "$non_hello_count" -gt 0 ]; then
-        return 1 # Not clean, user has other scripts
-      fi
-    fi
-
-    return 0 # Clean install
-  }
-
-  # Function to check if file is a hello example
-  is_hello_file() {
-    local file_path="$1"
-    for hello_file in "${hello_files[@]}"; do
-      if [[ "$file_path" == *"$hello_file" ]]; then
-        return 0
-      fi
-    done
-    return 1
-  }
-
-  # Function to check if file should be excluded
-  should_exclude() {
-    local file="$1"
-    local basename_file
-    basename_file="$(basename "$file")"
-
-    for pattern in "${exclude_patterns[@]}"; do
-      case "$basename_file" in
-        "$pattern") return 0 ;;
-      esac
-    done
-    return 1
-  }
-
-  # Function to calculate file checksum (cross-platform)
-  get_checksum() {
-    local file="$1"
-    if command -v sha256sum >/dev/null 2>&1; then
-      sha256sum "$file" | cut -d' ' -f1
-    elif command -v shasum >/dev/null 2>&1; then
-      shasum -a 256 "$file" | cut -d' ' -f1
-    elif command -v openssl >/dev/null 2>&1; then
-      openssl dgst -sha256 "$file" | cut -d' ' -f2
-    else
-      # Fallback to basic file comparison
-      wc -c <"$file"
-    fi
-  }
-
-  # Detect if this is a clean install
-  local clean_install
-  if is_clean_install "$dst"; then
-    clean_install=true
-    log_info "Clean install detected - will include hello examples"
-  else
-    clean_install=false
-    log_info "Existing installation detected - skipping hello examples"
-  fi
-
-  # Process each target directory
-  for dir in "${target_dirs[@]}"; do
-    local src_dir="$src/$dir"
-    local dst_dir="$dst/$dir"
-
-    if [ ! -d "$src_dir" ]; then
-      log_warn "Source directory $src_dir not found, skipping"
-      continue
-    fi
-
-    log_info "📂 $dir/"
-
-    # Find all files in source directory
-    while IFS= read -r -d '' src_file; do
-      # Skip if file should be excluded
-      if should_exclude "$src_file"; then
-        continue
-      fi
-
-      # Calculate relative path from src_dir
-      local rel_path="${src_file#$src_dir/}"
-      local full_rel_path="$dir/$rel_path"
-      local dst_file="$dst_dir/$rel_path"
-
-      # Skip hello files unless it's a clean install or force override
-      if is_hello_file "$full_rel_path"; then
-        if [ "$clean_install" = "false" ] && [ "$force_override" = "false" ]; then
-          printf "$(get_message "skipped" 1)" "$rel_path (example file, use --force to copy)"
-          continue
-        fi
-      fi
-
-      # Create directory structure if needed
-      mkdir -p "$(dirname "$dst_file")"
-
-      if [ -f "$dst_file" ]; then
-        # File exists, check if content is different
-        local src_checksum dst_checksum
-        src_checksum="$(get_checksum "$src_file")"
-        dst_checksum="$(get_checksum "$dst_file")"
-
-        if [ "$src_checksum" != "$dst_checksum" ]; then
-          modified_files_detected=true
-          if [ "$force_override" = "true" ]; then
-            printf "$(get_message "overwritten" 1)" "$rel_path"
-            cp "$src_file" "$dst_file"
-            # Preserve executable permissions
-            if [ -x "$src_file" ]; then
-              chmod +x "$dst_file"
-            fi
-          else
-            printf "$(get_message "file differs" 1)" "$rel_path"
-            # Track modified files for later reporting
-            modified_files+=("$dst_file")
-            modified_src_files+=("$src_file")
-          fi
-        else
-          printf "$(get_message "unchanged" 1)" "$rel_path"
-        fi
-      else
-        # File doesn't exist, copy it
-        printf "$(get_message "new file" 1)" "$rel_path"
-        cp "$src_file" "$dst_file"
-
-        # Preserve executable permissions
-        if [ -x "$src_file" ]; then
-          chmod +x "$dst_file"
-        fi
-      fi
-    done < <(find "$src_dir" -type f -print0)
-  done
-
-  # Copy specific root-level files
-  for file in "${root_files[@]}"; do
-    local src_file="$src/$file"
-    local dst_file="$dst/$file"
-
-    if [ -f "$src_file" ]; then
-      if [ -f "$dst_file" ]; then
-        # File exists, check if content is different
-        local src_checksum dst_checksum
-        src_checksum="$(get_checksum "$src_file")"
-        dst_checksum="$(get_checksum "$dst_file")"
-
-        if [ "$src_checksum" != "$dst_checksum" ]; then
-          modified_files_detected=true
-          if [ "$force_override" = "true" ]; then
-            printf "$(get_message "overwritten" 0)" "$file"
-            cp "$src_file" "$dst_file"
-          else
-            printf "$(get_message "file differs" 0)" "$file"
-            # Track modified files for later reporting
-            modified_files+=("$dst_file")
-            modified_src_files+=("$src_file")
-          fi
-        else
-          printf "$(get_message "unchanged" 0)" "$file"
-        fi
-      else
-        # File doesn't exist, copy it
-        printf "$(get_message "new file" 0)" "$file"
-        cp "$src_file" "$dst_file"
-      fi
-    fi
-  done
-
-  # Note: Fish completion is now handled via the .core folder
-  # The copy_core_files_recursively function above will copy it to ~/.config/dotrun/.core/
-  # Fish shell users should source it from there or it will be symlinked during shell integration
-
-  # Return status indicating if modifications were detected
-  if [ "$modified_files_detected" = "true" ] && [ "$force_override" = "false" ]; then
-    return 1 # Indicate modifications were detected but not overridden
-  else
-    return 0 # All good
-  fi
 }
 
 # Check if directory is writable
@@ -608,6 +354,28 @@ main() {
   fi
 
   # ------------------------------------------------------------------
+  # V3.0 Structure Validation
+  # ------------------------------------------------------------------
+
+  # Verify critical v3.0 files exist
+  local dr_config_loader="$shared_dir/.dr_config_loader"
+  if [ ! -f "$dr_config_loader" ]; then
+    log_error "Critical v3.0 file missing: .dr_config_loader"
+    log_error "Expected at: $dr_config_loader"
+    exit 1
+  fi
+
+  # Verify dr binary exists
+  local dr_binary="$shared_dir/dr"
+  if [ ! -f "$dr_binary" ]; then
+    log_error "Critical v3.0 file missing: dr binary"
+    log_error "Expected at: $dr_binary"
+    exit 1
+  fi
+
+  log_success "✓ V3.0 structure validated"
+
+  # ------------------------------------------------------------------
   # 3. Install binary via symlink
   # ------------------------------------------------------------------
 
@@ -625,13 +393,6 @@ main() {
   # Check if we can write to bin directory
   if ! is_writable "$bin_dir" 2>/dev/null; then
     log_error "Cannot write to $bin_dir - installation failed"
-    exit 1
-  fi
-
-  # Verify source binary exists in shared directory
-  if [ ! -f "$dr_source" ]; then
-    log_error "Source binary not found at $dr_source"
-    log_error "Expected to find it in ~/.local/share/dotrun/ after tool files setup"
     exit 1
   fi
 
@@ -668,29 +429,13 @@ main() {
     if [ -f "$drrc_source" ]; then
       log_info "Copying .drrc from core/home/"
       cp "$drrc_source" "$drrc_file"
-
-      # Update .drrc to point to new loader location
-      # The .dr_config_loader should be in ~/.local/share/dotrun/
-      sed -i.bak "s|\.config/dotrun/\.core/\.dr_config_loader|.local/share/dotrun/.dr_config_loader|g" "$drrc_file" 2>/dev/null \
-        || sed -i '' "s|\.config/dotrun/\.core/\.dr_config_loader|.local/share/dotrun/.dr_config_loader|g" "$drrc_file" 2>/dev/null
-      rm -f "$drrc_file.bak"
-
-      log_success "Created $drrc_file with updated paths"
+      log_success "Created $drrc_file"
     else
       log_error "Source file not found: $drrc_source"
       exit 1
     fi
   else
     log_info "$drrc_file already exists"
-
-    # Check if it needs to be updated to new paths
-    if grep -q "\.config/dotrun/\.core/\.dr_config_loader" "$drrc_file" 2>/dev/null; then
-      log_info "Updating $drrc_file to use new directory structure"
-      sed -i.bak "s|\.config/dotrun/\.core/\.dr_config_loader|.local/share/dotrun/.dr_config_loader|g" "$drrc_file" 2>/dev/null \
-        || sed -i '' "s|\.config/dotrun/\.core/\.dr_config_loader|.local/share/dotrun/.dr_config_loader|g" "$drrc_file" 2>/dev/null
-      rm -f "$drrc_file.bak"
-      log_success "Updated $drrc_file paths"
-    fi
   fi
 
   # Special handling for Fish completion - copy to fish completions directory
@@ -698,11 +443,6 @@ main() {
     local fish_completion_src="$shared_dir/shell/fish/dr_completion.fish"
     local fish_completion_dir="$INSTALL_CFG_PATH/fish/completions"
     local fish_completion_dst="$fish_completion_dir/dr.fish"
-
-    # Fallback to legacy path if new structure doesn't exist
-    if [ ! -f "$fish_completion_src" ]; then
-      fish_completion_src="$shared_dir/dr_completion.fish"
-    fi
 
     if [ -f "$fish_completion_src" ]; then
       if [ ! -d "$fish_completion_dir" ]; then
@@ -724,70 +464,6 @@ main() {
     else
       log_warn "Fish completion source not found at $fish_completion_src"
     fi
-  fi
-
-  # Create .drun_config_loader if it doesn't exist
-  local config_loader_file="$cfg_dir/.drun_config_loader"
-  if [ ! -f "$config_loader_file" ]; then
-    log_info "Creating $config_loader_file"
-
-    cat >"$config_loader_file" <<'EOF'
-#!/usr/bin/env bash
-
-source "$DRUN_CONFIG/helpers/pkg.sh"
-
-# DotRun Configuration
-# This file is managed by DotRun. Manual edits may be overwritten.
-# Use 'drun config set/get/unset' commands to manage configuration.
-
-#* =================== SHELL CONFIGURATIONS ====== *#
-export CURRENT_SHELL=$(detect_shell)
-
-# Add drun binary to PATH if not already present
-case ":$PATH:" in
-    *":$HOME/.local/bin:"*) ;;
-    *) export PATH="$HOME/.local/bin:$PATH" ;;
-esac
-
-SHELL_COMPLETION="$DRUN_CONFIG/drun_completion"
-SHELL_CONFIGS="$DRUN_CONFIG/config/shell"
-SHELL_ALIASES="$DRUN_CONFIG/aliases/shell"
-
-[[ $CURRENT_SHELL == "bash" ]] && {
-  SHELL_COMPLETION="$SHELL_COMPLETION.bash"
-  SHELL_CONFIGS="$SHELL_CONFIGS/bash_config"
-  SHELL_ALIASES="$SHELL_ALIASES/bash_aliases"
-}
-
-[[ $CURRENT_SHELL == "zsh" ]] && {
-  SHELL_COMPLETION="$SHELL_COMPLETION.zsh"
-  SHELL_CONFIGS="$SHELL_CONFIGS/zsh_config"
-  SHELL_ALIASES="$SHELL_ALIASES/zsh_aliases"
-}
-
-[[ $CURRENT_SHELL == "fish" ]] && {
-  SHELL_COMPLETION="$SHELL_COMPLETION.fish"
-  SHELL_CONFIGS="$SHELL_CONFIGS/fish_config"
-  SHELL_ALIASES="$SHELL_ALIASES/fish_aliases"
-}
-
-if [ -f "$SHELL_COMPLETION" ]; then
-  source "$SHELL_COMPLETION"
-fi
-
-if [ -f "$SHELL_ALIASES" ]; then
-  source "$SHELL_ALIASES"
-fi
-
-if [ -f "$SHELL_CONFIGS" ]; then
-  source "$SHELL_CONFIGS"
-fi
-
-EOF
-    chmod +x "$config_loader_file"
-    log_success "Created $config_loader_file"
-  else
-    log_info "$config_loader_file already exists, skipping creation"
   fi
 
   # ------------------------------------------------------------------
@@ -828,9 +504,6 @@ EOF
   printf "  🐚 Detected shell:   %s\n" "$shell_type"
   printf "  💻 Operating system: %s\n" "$os_type"
   echo
-
-
-
 
   if [ "$already_integrated" = "true" ]; then
     log_info "Shell integration already configured"
@@ -878,38 +551,6 @@ EOF
     echo
   fi
 
-  # If there were files with differences, show override commands
-  if [ "$binary_differs" = "true" ] || [ ${#modified_files[@]} -gt 0 ]; then
-    echo
-    log_warn "Some files were not updated due to existing modifications"
-    log_info "To selectively override files, use these commands:"
-    echo
-    
-    # Show binary override commands if needed
-    if [ "$binary_differs" = "true" ] && [ ${#override_files[@]} -gt 0 ]; then
-      for file in "${override_files[@]}"; do
-        local display_M_dst=$(echo "$file" | sed "s|^$HOME|~|")
-        local display_M_src=$(echo "$drun_source" | sed "s|^$HOME|~|")
-        printf "  \033[1;36mcp %s %s\033[0m\n" "$display_M_src" "$display_M_dst"
-      done
-    fi
-    
-    # Show other file override commands from the copy process
-    if [ ${#modified_files[@]} -gt 0 ]; then
-      for i in "${!modified_files[@]}"; do
-        local src_file="${modified_src_files[$i]}"
-        local dst_file="${modified_files[$i]}"
-        local display_M_dst=$(echo "$dst_file" | sed "s|^$HOME|~|")
-        local display_M_src=$(echo "$src_file" | sed "s|^$HOME|~|")
-        printf "  \033[1;36mcp %s %s\033[0m\n" "$display_M_src" "$display_M_dst"
-      done
-    fi
-    
-    echo
-    log_info "Or to override all modified files at once:"
-    printf "  \033[1;36m./install.sh --force\033[0m\n"
-    echo
-  fi
 }
 
 # ------------------------------------------------------------------

--- a/upgrade-v1-or-v2--to--v3.sh
+++ b/upgrade-v1-or-v2--to--v3.sh
@@ -217,8 +217,8 @@ show_migration_instructions() {
   local needs_migration=false
 
   # Check if any old structure exists
-  if [[ -d "$CONFIG_DIR/bin" ]] || [[ -d "$CONFIG_DIR/aliases/.d.aliases" ]] || \
-     [[ -d "$CONFIG_DIR/config" ]] || [[ -f "$CONFIG_DIR/.drun_config_loader" ]]; then
+  if [[ -d "$CONFIG_DIR/bin" ]] || [[ -d "$CONFIG_DIR/aliases/.d.aliases" ]] \
+    || [[ -d "$CONFIG_DIR/config" ]] || [[ -f "$CONFIG_DIR/.drun_config_loader" ]]; then
     needs_migration=true
   fi
 
@@ -248,7 +248,7 @@ show_migration_instructions() {
   # Aliases migration
   if [[ -d "$CONFIG_DIR/aliases/.d.aliases" ]] || [[ -f "$CONFIG_DIR/aliases/.aliases" ]] || [[ -d "$CONFIG_DIR/aliases/shell" ]]; then
     echo -e "${BLUE}📝 Aliases Files:${NC}"
-    
+
     if [[ -d "$CONFIG_DIR/aliases/.d.aliases" ]]; then
       echo -e "  ${YELLOW}OLD:${NC} ~/.config/dotrun/aliases/.d.aliases/*"
       echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/aliases/*.aliases"
@@ -256,14 +256,14 @@ show_migration_instructions() {
       echo -e "  ${BLUE}Action:${NC} rmdir ~/.config/dotrun/aliases/.d.aliases"
       echo ""
     fi
-    
+
     if [[ -f "$CONFIG_DIR/aliases/.aliases" ]]; then
       echo -e "  ${YELLOW}OLD:${NC} ~/.config/dotrun/aliases/.aliases"
       echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/aliases/10.main.aliases ${BLUE}(recommended)${NC}"
       echo -e "  ${BLUE}Action:${NC} mv ~/.config/dotrun/aliases/.aliases ~/.config/dotrun/aliases/10.main.aliases"
       echo ""
     fi
-    
+
     if [[ -d "$CONFIG_DIR/aliases/shell" ]]; then
       echo -e "  ${RED}REMOVE:${NC} ~/.config/dotrun/aliases/shell/ ${RED}(deprecated)${NC}"
       echo -e "  ${BLUE}Action:${NC} rm -rf ~/.config/dotrun/aliases/shell"
@@ -278,28 +278,28 @@ show_migration_instructions() {
     echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/configs/"
     echo -e "  ${BLUE}Action:${NC} mv ~/.config/dotrun/config ~/.config/dotrun/configs"
     echo ""
-    
+
     if [[ -d "$CONFIG_DIR/config/.dotrun_config.d" ]]; then
       echo -e "  ${YELLOW}OLD:${NC} ~/.config/dotrun/config/.dotrun_config.d/*"
       echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/configs/*.config"
       echo -e "  ${BLUE}Action:${NC} Move files from .dotrun_config.d/ to configs/ and add .config extension"
       echo ""
     fi
-    
+
     if [[ -f "$CONFIG_DIR/config/.dotrun_config" ]]; then
       echo -e "  ${YELLOW}OLD:${NC} ~/.config/dotrun/config/.dotrun_config"
       echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/configs/10.main.config ${BLUE}(recommended)${NC}"
       echo -e "  ${BLUE}Action:${NC} mv ~/.config/dotrun/config/.dotrun_config ~/.config/dotrun/configs/10.main.config"
       echo ""
     fi
-    
+
     if [[ -f "$CONFIG_DIR/config/.dotrun_config.secure" ]]; then
       echo -e "  ${YELLOW}OLD:${NC} ~/.config/dotrun/config/.dotrun_config.secure"
       echo -e "  ${GREEN}NEW:${NC} ~/.config/dotrun/configs/20.secure.config ${BLUE}(recommended)${NC}"
       echo -e "  ${BLUE}Action:${NC} mv ~/.config/dotrun/config/.dotrun_config.secure ~/.config/dotrun/configs/20.secure.config"
       echo ""
     fi
-    
+
     if [[ -d "$CONFIG_DIR/config/shell" ]]; then
       echo -e "  ${RED}REMOVE:${NC} ~/.config/dotrun/config/shell/ ${RED}(deprecated)${NC}"
       echo -e "  ${BLUE}Action:${NC} rm -rf ~/.config/dotrun/config/shell"


### PR DESCRIPTION

#### Enhanced Documentation System

- **Three-Tier Documentation Structure**: Scripts now support three `### DOC` blocks for progressive documentation depth
  - **Block 1→2**: One-line summary (shown in `dr -L` tree listing)
  - **Block 2→3**: Extended documentation with usage examples, required tools, and detailed descriptions
  - Enables both quick reference and comprehensive help in the same script

- **New `dr docs` Command**: Display extended documentation from scripts
  - **`dr docs <scriptname>`**: Shows content between **2nd and 3rd `### DOC` blocks** (extended documentation)
  - Includes usage examples, required tools, and detailed descriptions
  - Automatic fallback to basic docs (1st→2nd block) if script doesn't have 3rd DOC block
  - Complements existing `dr help` command for comprehensive documentation access

#### Enhanced List Commands (`dr -l` / `dr -L`)

- **Intelligent Sorting**: Both `dr -l` and `dr -L` now display results in organized hierarchy
  - **Folders first** (alphabetically sorted)
  - **Scripts second** (alphabetically sorted)
  - Applied recursively at all directory levels for consistent navigation

- **Tree-Style Output Format**: Beautiful tree CLI-style visualization
  - Unicode box-drawing characters: `├──`, `└──`, `│` for clear hierarchy
  - Proper last-item detection for clean visual structure (`└──` for final items)
  - Indentation preserved for documentation snippets

- **Colorized Folder Depth**: Visual depth indicators with automatic color cycling
  - 6-color palette cycles every 6 folder levels: Bright Blue → Bright Cyan → Bright Magenta → Orange → Yellow → Green
  - Color applies to all tree symbols (branches, connectors, and continuation lines)
  - Makes nested folder structures easy to visually parse

- **Documentation Display Behavior**:
  - **`dr -L`**: Now shows only content between **1st and 2nd `### DOC` blocks** (one-line summary)
  - Previous behavior showed all documentation between first and last DOC markers
  - Enables concise tree listing with brief descriptions

#### Externalized Script Templates

- **Template File System**: Script templates moved from inline code to external files
  - Template location: `~/.local/share/dotrun/core/templates/script.sh`
  - Source template: `core/shared/dotrun/core/templates/script.sh`
  - Enables easier template customization and maintenance
  - Templates automatically deployed during installation and upgrades

- **Updated Script Creation**: `dr set <name>` uses external template
  - Template includes new 3-block `### DOC` structure
  - Placeholder system: `{{SCRIPT_NAME}}` replaced during creation
  - Error handling for missing template files with actionable guidance

- **User-Customizable Templates**: Personalize script creation to match your workflow
  - Template file located at: `~/.local/share/dotrun/core/templates/script.sh`
  - **Users can manually edit this file** to create custom script templates
  - Modifications persist across script creations (will be overwritten on system upgrades)
  - Use `{{SCRIPT_NAME}}` placeholder for automatic script name substitution
  - Ideal for: adding custom headers, modifying default structure, including organization-specific conventions

### 🔧 Changed

- **Installation Scripts**: Both `install.sh` and `upgrade-v1-or-v2--to--v3.sh` now recursively copy core template files
- **Default Script Template**: Updated to support new documentation structure with three-tier DOC blocks

### 📖 Documentation

- Script template structure documented inline with examples
- Extended help documentation accessible via new `dr docs` command
- Tree listing improvements enhance discoverability of script organization